### PR TITLE
Reformat HTML, JS and CSS files for easier reading.

### DIFF
--- a/ARIA Menubar/css/global.css
+++ b/ARIA Menubar/css/global.css
@@ -1,147 +1,148 @@
 
 .clearfix:after {
-visibility: hidden;
-display: block;
-font-size: 0;
-content: " ";
-clear: both;
-height: 0;
+  visibility: hidden;
+  display: block;
+  font-size: 0;
+  content: " ";
+  clear: both;
+  height: 0;
 }
 .clearfix {
-display: inline-block;
+  display: inline-block;
 }
 * html .clearfix {
-height: 1%;
+  height: 1%;
 }
 .clearfix {
-display: block;
+  display: block;
 }
 
 body {
-text-align: center;
-font-family: Frutiger, "Frutiger Linotype", Univers, Calibri, "Gill Sans", "Gill Sans MT", "Myriad Pro", Myriad, "DejaVu Sans Condensed", "Liberation Sans", "Nimbus Sans L", Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif;
-font-size: 0.93em;
-background-color: #f5f5f5;
-color: #000;
+  text-align: center;
+  font-family: Frutiger, "Frutiger Linotype", Univers, Calibri, "Gill Sans", "Gill Sans MT", "Myriad Pro", Myriad, "DejaVu Sans Condensed", "Liberation Sans", "Nimbus Sans L", Tahoma, Geneva, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 0.93em;
+  background-color: #f5f5f5;
+  color: #000;
 }
 
 a:link, a:visited, a:active, a:hover {
-color: #0000b0;
+  color: #0000b0;
 }
 
 *:focus {
-outline: dashed 2px blue;
+  outline: dashed 2px blue;
 }
 
 .hidden {
-display: none;
-visibility: hidden;
+  display: none;
+  visibility: hidden;
 }
 
 div.pageContainer {
-max-width: 1100px;
-margin-left: auto;
-margin-right: auto;
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 div.headerBlock1 > div {
-text-align: left;
-float: left;
+  text-align: left;
+  float: left;
 }
 
 div.headerBlock1 div.searchBlock, div.headerBlock2 div.menubarWrapper {
-float: right;
+  float: right;
 }
 
 /*
-The following CSS rules include attribute role values in order to convey which elements require specific role assignments within the markup.
+ * The following CSS rules include attribute role values in order to convey which
+ * elements require specific role assignments within the markup.
 */
 
 div.menubarWrapper[role="application"] {
-font-family: Tahoma, Geneva, sans-serif;
-font-weight: bold;
-font-size: 16px;
-text-align: center;
-padding: 5px 8px;
+  font-family: Tahoma, Geneva, sans-serif;
+  font-weight: bold;
+  font-size: 16px;
+  text-align: center;
+  padding: 5px 8px;
 }
 
 div.menubarWrapper[role="application"] ul[role="menubar"], div.menubarWrapper[role="application"] ul[role="menu"] {
-list-style: none;
-padding: 0;
-margin: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
 div.menubarWrapper[role="application"] ul[role="menu"] {
-position: absolute;
-margin-top: 30px;
-margin-left: 10px;
-font-size: 13px;
-text-align: left;
-padding: 5px;
-border: 1px solid #dedede;
-background: #bdbdbd;
-filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#cacaca', endColorstr='#aeaeae'); /*  IE */
-background: -webkit-gradient(linear, left top, left bottom, from(#cacaca), to(#aeaeae)); /*  WebKit */
-background: -moz-linear-gradient(top,  #cacaca, #aeaeae);
-border-color: #000;
-color: #000;
-text-shadow: 0 1px 0 #d4d4d4;
--webkit-box-shadow: 0 1px 1px #c9c9c9, inset 0 1px 0 #d7d7d7;
--moz-box-shadow: 0 1px 1px #c9c9c9, inset 0 1px 0 #d7d7d7;
-box-shadow: 0 1px 1px #c9c9c9, inset 0 1px 0 #d7d7d7;
-border-radius: 4px;
+  position: absolute;
+  margin-top: 30px;
+  margin-left: 10px;
+  font-size: 13px;
+  text-align: left;
+  padding: 5px;
+  border: 1px solid #dedede;
+  background: #bdbdbd;
+  filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#cacaca', endColorstr='#aeaeae'); /*  IE */
+  background: -webkit-gradient(linear, left top, left bottom, from(#cacaca), to(#aeaeae)); /*  WebKit */
+  background: -moz-linear-gradient(top,  #cacaca, #aeaeae);
+  border-color: #000;
+  color: #000;
+  text-shadow: 0 1px 0 #d4d4d4;
+  -webkit-box-shadow: 0 1px 1px #c9c9c9, inset 0 1px 0 #d7d7d7;
+  -moz-box-shadow: 0 1px 1px #c9c9c9, inset 0 1px 0 #d7d7d7;
+  box-shadow: 0 1px 1px #c9c9c9, inset 0 1px 0 #d7d7d7;
+  border-radius: 4px;
 }
 
 div.menubarWrapper[role="application"] ul.nested-submenu[role="menu"] {
-margin-top: -4px;
-margin-left: 120px;
+  margin-top: -4px;
+  margin-left: 120px;
 }
 
 div.menubarWrapper[role="application"] ul[role="menubar"] > li[role="presentation"] {
-float: left;
-width: 150px;
+  float: left;
+  width: 150px;
 }
 
 div.menubarWrapper[role="application"] ul[role="menu"] > li[role="presentation"] {
-clear: both;
-margin: 3px 0px 3px 0px;
+  clear: both;
+  margin: 3px 0px 3px 0px;
 }
 
 div.menubarWrapper[role="application"] a[href][role="menuitem"] {
-float: left;
-width: 100px;
-text-decoration: none;
-padding: 5px 8px;
-border: 1px solid #dedede;
-background: #92dbf6;
-filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#abe4f8', endColorstr='#6fcef3'); /*  IE */
-background: -webkit-gradient(linear, left top, left bottom, from(#abe4f8), to(#6fcef3)); /*  WebKit */
-background: -moz-linear-gradient(top,  #abe4f8, #6fcef3);
-border-color: #000;
-color: #000;
-text-shadow: 0 1px 0 #b6e6f9;
--webkit-box-shadow: 0 1px 1px #d6d6d6, inset 0 1px 0 #c0ebfa;
--moz-box-shadow: 0 1px 1px #d6d6d6, inset 0 1px 0 #c0ebfa;
-box-shadow: 0 1px 1px #d6d6d6, inset 0 1px 0 #c0ebfa;
+  float: left;
+  width: 100px;
+  text-decoration: none;
+  padding: 5px 8px;
+  border: 1px solid #dedede;
+  background: #92dbf6;
+  filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#abe4f8', endColorstr='#6fcef3'); /*  IE */
+  background: -webkit-gradient(linear, left top, left bottom, from(#abe4f8), to(#6fcef3)); /*  WebKit */
+  background: -moz-linear-gradient(top,  #abe4f8, #6fcef3);
+  border-color: #000;
+  color: #000;
+  text-shadow: 0 1px 0 #b6e6f9;
+  -webkit-box-shadow: 0 1px 1px #d6d6d6, inset 0 1px 0 #c0ebfa;
+  -moz-box-shadow: 0 1px 1px #d6d6d6, inset 0 1px 0 #c0ebfa;
+  box-shadow: 0 1px 1px #d6d6d6, inset 0 1px 0 #c0ebfa;
 }
 
 div.menubarWrapper[role="application"] a[href][role="menuitem"]:hover {
-background: #9cedef;
-filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#b7f2f4', endColorstr='#7ce7ea'); /*  IE */
-background: -webkit-gradient(linear, left top, left bottom, from(#b7f2f4), to(#7ce7ea)); /*  WebKit */
-background: -moz-linear-gradient(top,  #b7f2f4, #7ce7ea);
-border-color: #90c6c8 #78bdc0 #65b6ba;
-color: #006400;
-text-shadow: 0 1px 0 #bef3f5;
--webkit-box-shadow: 0 1px 1px #d5d5d5, inset 0 1px 0 #c9f5f7;
--moz-box-shadow: 0 1px 1px #d5d5d5, inset 0 1px 0 #c9f5f7;
-box-shadow: 0 1px 1px #d5d5d5, inset 0 1px 0 #c9f5f7;
+  background: #9cedef;
+  filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#b7f2f4', endColorstr='#7ce7ea'); /*  IE */
+  background: -webkit-gradient(linear, left top, left bottom, from(#b7f2f4), to(#7ce7ea)); /*  WebKit */
+  background: -moz-linear-gradient(top,  #b7f2f4, #7ce7ea);
+  border-color: #90c6c8 #78bdc0 #65b6ba;
+  color: #006400;
+  text-shadow: 0 1px 0 #bef3f5;
+  -webkit-box-shadow: 0 1px 1px #d5d5d5, inset 0 1px 0 #c9f5f7;
+  -moz-box-shadow: 0 1px 1px #d5d5d5, inset 0 1px 0 #c9f5f7;
+  box-shadow: 0 1px 1px #d5d5d5, inset 0 1px 0 #c9f5f7;
 }
 
 div.menubarWrapper[role="application"] a[href][role="menuitem"] span.menuIcon:before {
-content: ' \25BC';
+  content: ' \25BC';
 }
 
 div.menubarWrapper[role="application"] a[href][role="menuitem"] span.menuIcon.right:before {
-content: ' \25B6';
+  content: ' \25B6';
 }

--- a/ARIA Menubar/js/aria_menubar_module.js
+++ b/ARIA Menubar/js/aria_menubar_module.js
@@ -20,7 +20,7 @@ This is true as well for all nested submenus that consist of UL elements that in
 'ul[role="menu"] > li[role="presentation"] > a[href][role="menuitem"]'
 
 (The A tag may include any additional HTML markup for styling purposes, but should not include any block-level elements.
-If SVG images are embedded within the structure anywhere, they must be removed from the tab order and hidden properly from ATs by adding all of the following attributes to the SVG element: focusable="false" role="presentation" aria-hidden="true" ) 
+If SVG images are embedded within the structure anywhere, they must be removed from the tab order and hidden properly from ATs by adding all of the following attributes to the SVG element: focusable="false" role="presentation" aria-hidden="true" )
 
 3. Whenever an A tag that includes role="menuitem" has an attached submenu, it must include the attribute data-submenu-id, which points to the unique ID of the referenced UL element that includes role="menu".
 
@@ -52,416 +52,416 @@ The ARIA Menubar Module should never be applied on a structure that does not ope
 
 (function($){
 
-	// Public function for configuring and setting up Menubar constructs on the page
-	window.ARIAMenuBar = function(config){
-		config = config || {};
-		var cmbc = this;
+  // Public function for configuring and setting up Menubar constructs on the page
+  window.ARIAMenuBar = function(config){
+    config = config || {};
+    var cmbc = this;
 
-		// Generic CSS selector that identifies the top level Menubar structure on each page.
-		var topMenuBarSelector = config.topMenuBarSelector || 'ul[role="menubar"]',
+    // Generic CSS selector that identifies the top level Menubar structure on each page.
+    var topMenuBarSelector = config.topMenuBarSelector || 'ul[role="menubar"]',
 
-		// Class name that toggles display:none for hiding and unhiding dynamically rendered submenus
-		hiddenClass = config.hiddenClass || 'hidden',
+    // Class name that toggles display:none for hiding and unhiding dynamically rendered submenus
+    hiddenClass = config.hiddenClass || 'hidden',
 
-		// Click handler that executes whenever an A tag that includes role="menuitem" is clicked
-		handleMenuItemClick = function(ev){
-			if (typeof config.handleMenuItemClick === 'function'){
-				config.handleMenuItemClick.apply(this, [ev]);
-			}
+    // Click handler that executes whenever an A tag that includes role="menuitem" is clicked
+    handleMenuItemClick = function(ev){
+      if (typeof config.handleMenuItemClick === 'function'){
+        config.handleMenuItemClick.apply(this, [ev]);
+      }
 
-			else{
-				top.location.href = this.href;
-			}
-		},
+      else{
+        top.location.href = this.href;
+      }
+    },
 
-		// Handle opening of dynamic submenus
-		openMenu = function(subMenu, menuContainer){
-			$(menuContainer).data('open', subMenu);
-			$(subMenu).data('index', 0);
+    // Handle opening of dynamic submenus
+    openMenu = function(subMenu, menuContainer){
+      $(menuContainer).data('open', subMenu);
+      $(subMenu).data('index', 0);
 
-			if (typeof config.openMenu === 'function'){
-				config.openMenu.apply(this, [subMenu, menuContainer]);
-			}
+      if (typeof config.openMenu === 'function'){
+        config.openMenu.apply(this, [subMenu, menuContainer]);
+      }
 
-			else{
-				$(subMenu).removeClass(hiddenClass);
+      else{
+        $(subMenu).removeClass(hiddenClass);
 
-				if (cmbc.cb && typeof cmbc.cb === 'function'){
-					cmbc.cb();
-					cmbc.cb = null;
-				}
-			}
-		},
+        if (cmbc.cb && typeof cmbc.cb === 'function'){
+          cmbc.cb();
+          cmbc.cb = null;
+        }
+      }
+    },
 
-		// Handle closing of dynamic submenus
-		closeMenu = function(subMenu, closeAll, menuBar){
-			if (!subMenu)
-				return;
-			var menuBar = menuBar || $(subMenu).data('menuBar');
+    // Handle closing of dynamic submenus
+    closeMenu = function(subMenu, closeAll, menuBar){
+      if (!subMenu)
+        return;
+      var menuBar = menuBar || $(subMenu).data('menuBar');
 
-			if (closeAll){
-				var subMenus = $(menuBar).data('subMenus');
+      if (closeAll){
+        var subMenus = $(menuBar).data('subMenus');
 
-				for (var i = 0; i < subMenus.length; i++){
-					closeMenu.apply(this, [subMenus[i], false, menuBar]);
-				}
-			}
+        for (var i = 0; i < subMenus.length; i++){
+          closeMenu.apply(this, [subMenus[i], false, menuBar]);
+        }
+      }
 
-			else{
+      else{
 
-				var triggeringMenuItem = $(subMenu).data('triggeringMenuItem'),
-					parentMenuContainer = $(triggeringMenuItem).data('menuContainer');
-				$(parentMenuContainer).data('open', null);
-				$($(parentMenuContainer).data('menuItems')[$(parentMenuContainer).data('index')]).attr('tabindex', 0);
+        var triggeringMenuItem = $(subMenu).data('triggeringMenuItem'),
+          parentMenuContainer = $(triggeringMenuItem).data('menuContainer');
+        $(parentMenuContainer).data('open', null);
+        $($(parentMenuContainer).data('menuItems')[$(parentMenuContainer).data('index')]).attr('tabindex', 0);
 
-				if (subMenu != menuBar){
-					$(subMenu).data('index', 0);
+        if (subMenu != menuBar){
+          $(subMenu).data('index', 0);
 
-					if (typeof config.closeMenu === 'function'){
-						config.closeMenu.apply(this, [subMenu]);
-					}
+          if (typeof config.closeMenu === 'function'){
+            config.closeMenu.apply(this, [subMenu]);
+          }
 
-					else{
-						$(subMenu).addClass(hiddenClass);
-					}
-				}
+          else{
+            $(subMenu).addClass(hiddenClass);
+          }
+        }
 
-				$($(subMenu).data('menuItems')).attr('tabindex', -1);
-			}
-		},
+        $($(subMenu).data('menuItems')).attr('tabindex', -1);
+      }
+    },
 
-		// Accessible offscreen text to specify necessary keyboard directives for non-sighted users.
-		// (The below wording is important, so don't change this unless absolutely necessary)
-		dualHorizontalTxt = config.dualHorizontalTxt || 'Press Enter to navigate to page, or Down to open dropdown',
-			dualVerticalTxt = config.dualVerticalTxt || 'Press Enter to navigate to page, or Right to open dropdown',
-			horizontalTxt = config.horizontalTxt || 'Press Down to open dropdown',
-			verticalTxt = config.verticalTxt || 'Press Right to open dropdown',
+    // Accessible offscreen text to specify necessary keyboard directives for non-sighted users.
+    // (The below wording is important, so don't change this unless absolutely necessary)
+    dualHorizontalTxt = config.dualHorizontalTxt || 'Press Enter to navigate to page, or Down to open dropdown',
+      dualVerticalTxt = config.dualVerticalTxt || 'Press Enter to navigate to page, or Right to open dropdown',
+      horizontalTxt = config.horizontalTxt || 'Press Down to open dropdown',
+      verticalTxt = config.verticalTxt || 'Press Right to open dropdown',
 
-		// Recursively setup each Menubar on the page
-		setupMenubar = function(tmbSelector){
-			$(tmbSelector).each(function(i, menuBar){
-				$(menuBar).data('subMenus', []);
-				setupMenuItems(menuBar, menuBar, true);
-				$($(menuBar).data('menuItems')[0]).attr('tabindex', 0);
-			});
-		},
+    // Recursively setup each Menubar on the page
+    setupMenubar = function(tmbSelector){
+      $(tmbSelector).each(function(i, menuBar){
+        $(menuBar).data('subMenus', []);
+        setupMenuItems(menuBar, menuBar, true);
+        $($(menuBar).data('menuItems')[0]).attr('tabindex', 0);
+      });
+    },
 
 // Recursively setup each A tag that includes role="menuitem" within individual role="menubar" and role="menu" UL tags.
-		setupMenuItems = function(menuContainer, menuBar, isTopLvl){
-			var isHorizontal = -1, menuId = null, menuItems = [];
+    setupMenuItems = function(menuContainer, menuBar, isTopLvl){
+      var isHorizontal = -1, menuId = null, menuItems = [];
 
-			if ($(menuContainer).attr('role') == 'menubar')
-				isHorizontal = $(menuContainer).hasClass('vertical') ? false : true;
+      if ($(menuContainer).attr('role') == 'menubar')
+        isHorizontal = $(menuContainer).hasClass('vertical') ? false : true;
 
-			else if ($(menuContainer).attr('role') == 'menu')
-				isHorizontal = $(menuContainer).hasClass('horizontal') ? true : false;
-			menuId = $(menuContainer).attr('id');
+      else if ($(menuContainer).attr('role') == 'menu')
+        isHorizontal = $(menuContainer).hasClass('horizontal') ? true : false;
+      menuId = $(menuContainer).attr('id');
 
-			if (isHorizontal === -1){
-				alert(
-					'Syntax error: menuContainer must include either role=menubar for the top level container, or role=menu for submenu structures.');
-				return;
-			}
+      if (isHorizontal === -1){
+        alert(
+          'Syntax error: menuContainer must include either role=menubar for the top level container, or role=menu for submenu structures.');
+        return;
+      }
 
-			else if (!menuId){
-				alert(
-					'Syntax error: All instances of menuContainer including role=menubar for the top level container, or role=menu for submenu structures, must include a unique ID.');
-				return;
-			}
+      else if (!menuId){
+        alert(
+          'Syntax error: All instances of menuContainer including role=menubar for the top level container, or role=menu for submenu structures, must include a unique ID.');
+        return;
+      }
 
-			$(menuContainer).attr('aria-orientation', isHorizontal ? 'horizontal' : 'vertical');
+      $(menuContainer).attr('aria-orientation', isHorizontal ? 'horizontal' : 'vertical');
 
-			$('#' + menuId + ' > li > a[role="menuitem"]').each(function(j, menuItem){
-				$(menuItem).data('menuContainer', $(menuContainer)[0]).data('isHorizontal', isHorizontal).data('menuBar',
-					$(menuBar)[0]).attr('tabindex', -1);
-				var subMenuId = $(menuItem).attr('data-submenu-id') || null;
+      $('#' + menuId + ' > li > a[role="menuitem"]').each(function(j, menuItem){
+        $(menuItem).data('menuContainer', $(menuContainer)[0]).data('isHorizontal', isHorizontal).data('menuBar',
+          $(menuBar)[0]).attr('tabindex', -1);
+        var subMenuId = $(menuItem).attr('data-submenu-id') || null;
 
-				if (subMenuId){
-					var subMenu = $('#' + subMenuId)[0] || null;
+        if (subMenuId){
+          var subMenu = $('#' + subMenuId)[0] || null;
 
-					if (!subMenu){
-						alert('Syntax error: data-submenu-id must reference a valid role=menu container.');
-						return;
-					}
-					$(menuItem).attr('aria-haspopup', 'true');
-					$(menuBar).data('subMenus').push($(subMenu)[0]);
-					$(menuItem).data('subMenu', $(subMenu)[0]).data('navigatesAway',
-						$(menuItem).hasClass('navigates-away') ? true : false);
+          if (!subMenu){
+            alert('Syntax error: data-submenu-id must reference a valid role=menu container.');
+            return;
+          }
+          $(menuItem).attr('aria-haspopup', 'true');
+          $(menuBar).data('subMenus').push($(subMenu)[0]);
+          $(menuItem).data('subMenu', $(subMenu)[0]).data('navigatesAway',
+            $(menuItem).hasClass('navigates-away') ? true : false);
 
-					if (!('ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0)){
-						if ($(menuItem).data('navigatesAway')){
-							if (isHorizontal)
-								$('<span>').css(offscreenCSS).appendTo(menuItem).text(dualHorizontalTxt);
+          if (!('ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0)){
+            if ($(menuItem).data('navigatesAway')){
+              if (isHorizontal)
+                $('<span>').css(offscreenCSS).appendTo(menuItem).text(dualHorizontalTxt);
 
-							else
-								$('<span>').css(offscreenCSS).appendTo(menuItem).text(dualVerticalTxt);
-						}
+              else
+                $('<span>').css(offscreenCSS).appendTo(menuItem).text(dualVerticalTxt);
+            }
 
-						else{
-							if (isHorizontal)
-								$('<span>').css(offscreenCSS).appendTo(menuItem).text(horizontalTxt);
+            else{
+              if (isHorizontal)
+                $('<span>').css(offscreenCSS).appendTo(menuItem).text(horizontalTxt);
 
-							else
-								$('<span>').css(offscreenCSS).appendTo(menuItem).text(verticalTxt);
-						}
-					}
-					$(subMenu).data('triggeringMenuItem', $(menuItem)[0]).data('menuBar', $(menuBar)[0]);
-					$(subMenu).bind(
-									{
-									mouseleave: function(ev){
-										var open = $(this).data('open');
+              else
+                $('<span>').css(offscreenCSS).appendTo(menuItem).text(verticalTxt);
+            }
+          }
+          $(subMenu).data('triggeringMenuItem', $(menuItem)[0]).data('menuBar', $(menuBar)[0]);
+          $(subMenu).bind(
+                  {
+                  mouseleave: function(ev){
+                    var open = $(this).data('open');
 
-										if (!open)
-											closeMenu.apply(this, [this]);
+                    if (!open)
+                      closeMenu.apply(this, [this]);
 
-										ev.stopPropagation();
-									}
-									});
-					setupMenuItems($(subMenu)[0], $(menuBar)[0]);
-				}
-				menuItems.push($(menuItem)[0]);
-			});
+                    ev.stopPropagation();
+                  }
+                  });
+          setupMenuItems($(subMenu)[0], $(menuBar)[0]);
+        }
+        menuItems.push($(menuItem)[0]);
+      });
 
-			bindEvents(menuItems, isTopLvl);
-			$(menuContainer).data('menuItems', menuItems).data('index', 0);
-		},
+      bindEvents(menuItems, isTopLvl);
+      $(menuContainer).data('menuItems', menuItems).data('index', 0);
+    },
 
-		// Setup event bindings for every A tag that includes role="menuitem"
-		bindEvents = function(menuItems, isTopLvl){
-			if (!menuItems.length)
-				return;
+    // Setup event bindings for every A tag that includes role="menuitem"
+    bindEvents = function(menuItems, isTopLvl){
+      if (!menuItems.length)
+        return;
 
-			$(menuItems).each(function(i, mI){
+      $(menuItems).each(function(i, mI){
 
-				$(mI).bind(
-								{
-								keydown: function(ev){
-									var k = ev.which || ev.keyCode;
+        $(mI).bind(
+                {
+                keydown: function(ev){
+                  var k = ev.which || ev.keyCode;
 
-									if ((k >= 37 && k <= 40) || k == 13 || k == 32 || k == 27 || k == 9){
-										var isHorizontal = $(this).data('isHorizontal'), navigatesAway = $(this).data('navigatesAway'),
-											subMenu = $(this).data('subMenu'), menuContainer = $(this).data('menuContainer'),
-											index = $(menuContainer).data('index'), menuItems = $(menuContainer).data('menuItems'),
-											triggeringMenuItem = $(menuContainer).data('triggeringMenuItem'),
-											parentMenuContainer = $(triggeringMenuItem).data('menuContainer'), menuBar = $(this).data('menuBar');
+                  if ((k >= 37 && k <= 40) || k == 13 || k == 32 || k == 27 || k == 9){
+                    var isHorizontal = $(this).data('isHorizontal'), navigatesAway = $(this).data('navigatesAway'),
+                      subMenu = $(this).data('subMenu'), menuContainer = $(this).data('menuContainer'),
+                      index = $(menuContainer).data('index'), menuItems = $(menuContainer).data('menuItems'),
+                      triggeringMenuItem = $(menuContainer).data('triggeringMenuItem'),
+                      parentMenuContainer = $(triggeringMenuItem).data('menuContainer'), menuBar = $(this).data('menuBar');
 
-										if (k == 37){
-											if (isHorizontal){
-												if (!index)
-													index = menuItems.length - 1;
+                    if (k == 37){
+                      if (isHorizontal){
+                        if (!index)
+                          index = menuItems.length - 1;
 
-												else
-													index--;
-												$(menuContainer).data('index', index);
-												setFocus($(menuItems)[index], menuItems);
-											}
+                        else
+                          index--;
+                        $(menuContainer).data('index', index);
+                        setFocus($(menuItems)[index], menuItems);
+                      }
 
-											else{
-												closeMenu.apply(this, [menuContainer]);
+                      else{
+                        closeMenu.apply(this, [menuContainer]);
 
-												if (parentMenuContainer && parentMenuContainer != menuBar && triggeringMenuItem){
-													setFocus($(parentMenuContainer).data('menuItems')[$(parentMenuContainer).data('index')],
-														$(parentMenuContainer).data('menuItems'), menuItems);
-												}
+                        if (parentMenuContainer && parentMenuContainer != menuBar && triggeringMenuItem){
+                          setFocus($(parentMenuContainer).data('menuItems')[$(parentMenuContainer).data('index')],
+                            $(parentMenuContainer).data('menuItems'), menuItems);
+                        }
 
-												else if (parentMenuContainer && parentMenuContainer == menuBar && triggeringMenuItem){
-													index = $(menuBar).data('index');
-													menuItems = $(menuBar).data('menuItems');
+                        else if (parentMenuContainer && parentMenuContainer == menuBar && triggeringMenuItem){
+                          index = $(menuBar).data('index');
+                          menuItems = $(menuBar).data('menuItems');
 
-													if (!index)
-														index = menuItems.length - 1;
+                          if (!index)
+                            index = menuItems.length - 1;
 
-													else
-														index--;
-													$(menuBar).data('index', index);
-													setFocus($(menuItems)[index], menuItems);
-												}
-											}
-											ev.preventDefault();
-										}
+                          else
+                            index--;
+                          $(menuBar).data('index', index);
+                          setFocus($(menuItems)[index], menuItems);
+                        }
+                      }
+                      ev.preventDefault();
+                    }
 
-										else if (k == 38){
-											if (!isHorizontal){
-												if (!index)
-													index = menuItems.length - 1;
+                    else if (k == 38){
+                      if (!isHorizontal){
+                        if (!index)
+                          index = menuItems.length - 1;
 
-												else
-													index--;
-												$(menuContainer).data('index', index);
-												setFocus($(menuItems)[index], menuItems);
-											}
+                        else
+                          index--;
+                        $(menuContainer).data('index', index);
+                        setFocus($(menuItems)[index], menuItems);
+                      }
 
-											else{
-												closeMenu.apply(this, [menuContainer]);
-											}
-											ev.preventDefault();
-										}
+                      else{
+                        closeMenu.apply(this, [menuContainer]);
+                      }
+                      ev.preventDefault();
+                    }
 
-										else if (k == 39){
-											if (isHorizontal){
-												if (index >= menuItems.length - 1)
-													index = 0;
+                    else if (k == 39){
+                      if (isHorizontal){
+                        if (index >= menuItems.length - 1)
+                          index = 0;
 
-												else
-													index++;
-												$(menuContainer).data('index', index);
-												setFocus($(menuItems)[index], menuItems);
-											}
+                        else
+                          index++;
+                        $(menuContainer).data('index', index);
+                        setFocus($(menuItems)[index], menuItems);
+                      }
 
-											else{
-												if (subMenu){
-													cmbc.cb = function(){
-														setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
-															cmbc.cb.menuItems);
-													};
-													cmbc.cb.subMenu = subMenu;
-													cmbc.cb.menuItems = menuItems;
-													openMenu.apply(this, [subMenu, menuContainer]);
-												}
+                      else{
+                        if (subMenu){
+                          cmbc.cb = function(){
+                            setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
+                              cmbc.cb.menuItems);
+                          };
+                          cmbc.cb.subMenu = subMenu;
+                          cmbc.cb.menuItems = menuItems;
+                          openMenu.apply(this, [subMenu, menuContainer]);
+                        }
 
-												else{
-												closeMenu.apply(this, [menuContainer, true]);
-													index = $(menuBar).data('index');
-													menuItems = $(menuBar).data('menuItems');
+                        else{
+                        closeMenu.apply(this, [menuContainer, true]);
+                          index = $(menuBar).data('index');
+                          menuItems = $(menuBar).data('menuItems');
 
-													if (index >= menuItems.length - 1)
-														index = 0;
+                          if (index >= menuItems.length - 1)
+                            index = 0;
 
-													else
-														index++;
-													$(menuBar).data('index', index);
-													setFocus($(menuItems)[index], menuItems);
-												}
-											}
-											ev.preventDefault();
-										}
+                          else
+                            index++;
+                          $(menuBar).data('index', index);
+                          setFocus($(menuItems)[index], menuItems);
+                        }
+                      }
+                      ev.preventDefault();
+                    }
 
-										else if (k == 40){
-											if (!isHorizontal){
-												if (index >= menuItems.length - 1)
-													index = 0;
+                    else if (k == 40){
+                      if (!isHorizontal){
+                        if (index >= menuItems.length - 1)
+                          index = 0;
 
-												else
-													index++;
-												$(menuContainer).data('index', index);
-												$($(menuItems)[index]).focus();
-											}
+                        else
+                          index++;
+                        $(menuContainer).data('index', index);
+                        $($(menuItems)[index]).focus();
+                      }
 
-											else{
-												if (subMenu){
-													cmbc.cb = function(){
-														setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
-															cmbc.cb.menuItems);
-													};
-													cmbc.cb.subMenu = subMenu;
-													cmbc.cb.menuItems = menuItems;
-													openMenu.apply(this, [subMenu, menuContainer]);
-												}
-											}
-											ev.preventDefault();
-										}
+                      else{
+                        if (subMenu){
+                          cmbc.cb = function(){
+                            setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
+                              cmbc.cb.menuItems);
+                          };
+                          cmbc.cb.subMenu = subMenu;
+                          cmbc.cb.menuItems = menuItems;
+                          openMenu.apply(this, [subMenu, menuContainer]);
+                        }
+                      }
+                      ev.preventDefault();
+                    }
 
-										else if (k == 13 || k == 32){
-											if (subMenu && !navigatesAway){
-												cmbc.cb = function(){
-													setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
-														cmbc.cb.menuItems);
-												};
-												cmbc.cb.subMenu = subMenu;
-												cmbc.cb.menuItems = menuItems;
-													openMenu.apply(this, [subMenu, menuContainer]);
-											}
+                    else if (k == 13 || k == 32){
+                      if (subMenu && !navigatesAway){
+                        cmbc.cb = function(){
+                          setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
+                            cmbc.cb.menuItems);
+                        };
+                        cmbc.cb.subMenu = subMenu;
+                        cmbc.cb.menuItems = menuItems;
+                          openMenu.apply(this, [subMenu, menuContainer]);
+                      }
 
-											else{
-												$(this).click();
-											}
-											ev.preventDefault();
-										}
+                      else{
+                        $(this).click();
+                      }
+                      ev.preventDefault();
+                    }
 
-										else if (k == 27 || k == 9){
-											if (menuContainer == menuBar){
-												closeMenu.apply(this, [$(menuBar).data('open'), true, menuBar]);
-											}
+                    else if (k == 27 || k == 9){
+                      if (menuContainer == menuBar){
+                        closeMenu.apply(this, [$(menuBar).data('open'), true, menuBar]);
+                      }
 
-											else{
-												if (k == 27 && parentMenuContainer == menuBar)
-													$(menuBar).data('stopFocus', true);
-												closeMenu.apply(this, [menuContainer, k == 9 ? true : false, menuBar]);
+                      else{
+                        if (k == 27 && parentMenuContainer == menuBar)
+                          $(menuBar).data('stopFocus', true);
+                        closeMenu.apply(this, [menuContainer, k == 9 ? true : false, menuBar]);
 
-												if (k == 27 && triggeringMenuItem){
-													setFocus(triggeringMenuItem, $($(triggeringMenuItem).data('menuContainer')).data('menuItems'), menuItems);
-													ev.preventDefault();
-												}
-											}
-										}
-									}
-								},
-								click: function(ev){
-									var navigatesAway = $(this).data('navigatesAway'), subMenu = $(this).data('subMenu'),
-										menuContainer = $(this).data('menuContainer'), menuBar = $(this).data('menuBar');
+                        if (k == 27 && triggeringMenuItem){
+                          setFocus(triggeringMenuItem, $($(triggeringMenuItem).data('menuContainer')).data('menuItems'), menuItems);
+                          ev.preventDefault();
+                        }
+                      }
+                    }
+                  }
+                },
+                click: function(ev){
+                  var navigatesAway = $(this).data('navigatesAway'), subMenu = $(this).data('subMenu'),
+                    menuContainer = $(this).data('menuContainer'), menuBar = $(this).data('menuBar');
 
-									if (subMenu && !navigatesAway){
-										cmbc.cb = function(){
-											setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
-												cmbc.cb.menuItems);
-										};
-										cmbc.cb.subMenu = subMenu;
-										cmbc.cb.menuItems = menuItems;
-													openMenu.apply(this, [subMenu, menuContainer]);
-									}
+                  if (subMenu && !navigatesAway){
+                    cmbc.cb = function(){
+                      setFocus($($(cmbc.cb.subMenu).data('menuItems'))[0], $(cmbc.cb.subMenu).data('menuItems'),
+                        cmbc.cb.menuItems);
+                    };
+                    cmbc.cb.subMenu = subMenu;
+                    cmbc.cb.menuItems = menuItems;
+                          openMenu.apply(this, [subMenu, menuContainer]);
+                  }
 
-									else{
-										closeMenu.apply(this, [menuContainer, true, menuBar]);
-										handleMenuItemClick.apply(this, [ev]);
-									}
-									ev.preventDefault();
-								}
-								});
+                  else{
+                    closeMenu.apply(this, [menuContainer, true, menuBar]);
+                    handleMenuItemClick.apply(this, [ev]);
+                  }
+                  ev.preventDefault();
+                }
+                });
 
-				if (isTopLvl)
-					$(mI).bind(
-									{
-									'focus mouseenter': function(ev){
-										var menuItem = this, menuContainer = $(menuItem).data('menuContainer'), subMenu = $(menuItem).data('subMenu'),
-											menuBar = $(menuItem).data('menuBar'), open = $(menuBar).data('open'),
-											stopFocus = $(menuBar).data('stopFocus');
+        if (isTopLvl)
+          $(mI).bind(
+                  {
+                  'focus mouseenter': function(ev){
+                    var menuItem = this, menuContainer = $(menuItem).data('menuContainer'), subMenu = $(menuItem).data('subMenu'),
+                      menuBar = $(menuItem).data('menuBar'), open = $(menuBar).data('open'),
+                      stopFocus = $(menuBar).data('stopFocus');
 
-										if (open && open != subMenu){
-											closeMenu.apply(this, [open, true, menuBar]);
-											open = null;
-										}
+                    if (open && open != subMenu){
+                      closeMenu.apply(this, [open, true, menuBar]);
+                      open = null;
+                    }
 
-										if (!open && subMenu && !stopFocus)
-													openMenu.apply(this, [subMenu, menuBar]);
+                    if (!open && subMenu && !stopFocus)
+                          openMenu.apply(this, [subMenu, menuBar]);
 
-										$(menuBar).data('stopFocus', null);
-									}
-									});
-			});
-		},
+                    $(menuBar).data('stopFocus', null);
+                  }
+                  });
+      });
+    },
 
-		// Handle setting focus between role="menuitem" elements
-		setFocus = function(menuItem, menuItems, parentMenuItems){
-			$(parentMenuItems).attr('tabindex', '-1');
-			$(menuItems).attr('tabindex', '-1');
-			$(menuItem).attr('tabindex', '0').focus();
-		},
+    // Handle setting focus between role="menuitem" elements
+    setFocus = function(menuItem, menuItems, parentMenuItems){
+      $(parentMenuItems).attr('tabindex', '-1');
+      $(menuItems).attr('tabindex', '-1');
+      $(menuItem).attr('tabindex', '0').focus();
+    },
 
-		// CSS for hiding accessible offscreen text in a manner that doesn't conflict with touch devices
-		offscreenCSS =
-						{
-						position: 'absolute',
-						clip: 'rect(1px 1px 1px 1px)',
-						clip: 'rect(1px, 1px, 1px, 1px)',
-						padding: 0,
-						border: 0,
-						height: '1px',
-						width: '1px',
-						overflow: 'hidden',
-						zIndex: -1000
-						};
+    // CSS for hiding accessible offscreen text in a manner that doesn't conflict with touch devices
+    offscreenCSS =
+            {
+            position: 'absolute',
+            clip: 'rect(1px 1px 1px 1px)',
+            clip: 'rect(1px, 1px, 1px, 1px)',
+            padding: 0,
+            border: 0,
+            height: '1px',
+            width: '1px',
+            overflow: 'hidden',
+            zIndex: -1000
+            };
 
-		// Start checking for role="menubar" constructs on the loaded page
-		setupMenubar(topMenuBarSelector);
-	};
+    // Start checking for role="menubar" constructs on the loaded page
+    setupMenubar(topMenuBarSelector);
+  };
 })($);

--- a/ARIA Menubar/js/setup.js
+++ b/ARIA Menubar/js/setup.js
@@ -2,46 +2,45 @@
 
 $(function(){
 
-	// Create a new MenuBar instance
+  // Create a new MenuBar instance
 
-	var myMB = new ARIAMenuBar(
-					{
-					// Optional config overrides
+  var myMB = new ARIAMenuBar({
+    // Optional config overrides
 
-					// Generic CSS selector that identifies the top level Menubar structure on each page.
-					topMenuBarSelector: 'ul[role="menubar"]',
+    // Generic CSS selector that identifies the top level Menubar structure on each page.
+    topMenuBarSelector: 'ul[role="menubar"]',
 
-					// Class name that toggles display:none for hiding and unhiding dynamically rendered submenus
-					hiddenClass: 'hidden',
+    // Class name that toggles display:none for hiding and unhiding dynamically rendered submenus
+    hiddenClass: 'hidden',
 
-					// Click handler that executes whenever an A tag that includes role="menuitem" is clicked
-					handleMenuItemClick: function(ev){
-						top.location.href = this.href;
-					},
+    // Click handler that executes whenever an A tag that includes role="menuitem" is clicked
+    handleMenuItemClick: function(ev){
+      top.location.href = this.href;
+    },
 
-					// Handle opening of dynamic submenus
-					openMenu: function(subMenu, menuContainer){
-						$(subMenu).removeClass('hidden');
+    // Handle opening of dynamic submenus
+    openMenu: function(subMenu, menuContainer){
+      $(subMenu).removeClass('hidden');
 
-// Focus callback for use when adding animation effect; must be moved into animation callback after animation finishes rendering
-						if (myMB.cb && typeof myMB.cb === 'function'){
-							myMB.cb();
-							myMB.cb = null;
-						}
-					},
+      // Focus callback for use when adding animation effect; must be moved into animation callback after animation finishes rendering
+      if (myMB.cb && typeof myMB.cb === 'function'){
+        myMB.cb();
+        myMB.cb = null;
+      }
+    },
 
-					// Handle closing of dynamic submenus
-					closeMenu: function(subMenu){
-						$(subMenu).addClass('hidden');
-					},
+    // Handle closing of dynamic submenus
+    closeMenu: function(subMenu){
+      $(subMenu).addClass('hidden');
+    },
 
-					// Accessible offscreen text to specify necessary keyboard directives for non-sighted users.
-					// (The below wording is important, so don't change this unless absolutely necessary)
-					dualHorizontalTxt: 'Press Enter to navigate to page, or Down to open dropdown',
-					dualVerticalTxt: 'Press Enter to navigate to page, or Right to open dropdown',
-					horizontalTxt: 'Press Down to open dropdown',
-					verticalTxt: 'Press Right to open dropdown'
+    // Accessible offscreen text to specify necessary keyboard directives for non-sighted users.
+    // (The below wording is important, so don't change this unless absolutely necessary)
+    dualHorizontalTxt: 'Press Enter to navigate to page, or Down to open dropdown',
+    dualVerticalTxt: 'Press Enter to navigate to page, or Right to open dropdown',
+    horizontalTxt: 'Press Down to open dropdown',
+    verticalTxt: 'Press Right to open dropdown'
 
-					//
-					});
+    //
+  });
 });

--- a/ARIA Menubar/menubar.html
+++ b/ARIA Menubar/menubar.html
@@ -1,175 +1,220 @@
 <html>
-				<head>
-								<link rel="stylesheet" type="text/css" href="css/global.css">
-								<script type="text/javascript" src="js/jQuery.js">
-								</script>
+  <head>
+    <link rel="stylesheet" type="text/css" href="css/global.css">
+    <script type="text/javascript" src="js/jQuery.js"></script>
+    <script type="text/javascript" src="js/aria_menubar_module.min.js"></script>
 
-								<script type="text/javascript" src="js/aria_menubar_module.min.js">
-								</script>
+    <script type="text/javascript" src="js/setup.js"></script>
+  </head>
 
-								<script type="text/javascript" src="js/setup.js">
-								</script>
-				</head>
+  <body>
+    <div class="pageContainer">
+      <div role="banner" aria-label="top">
+        <div class="headerBlock1 clearfix">
+          <div class="logoLnk">
+            <a href="#" onclick="return false"> Standard link for logo </a>
+          </div>
 
-				<body>
-								<div class="pageContainer">
-												<div role="banner" aria-label="top">
-																<div class="headerBlock1 clearfix">
-																				<div class="logoLnk">
-																								<a href="#" onclick="return false"> Standard link for logo </a>
-																				</div>
+          <div class="searchBlock">
+            <label for="searchInput"> Search</label>
 
-																				<div class="searchBlock">
-																								<label for="searchInput"> Search</label>
+            <input type="text" id="searchInput" />
 
-																								<input type="text" id="searchInput" />
+            <button> Search </button>
+          </div>
+        </div>
 
-																								<button> Search </button>
-																				</div>
-																</div>
+        <div class="headerBlock2 clearfix">
 
-																<div class="headerBlock2 clearfix">
+    <!-- IMPORTANT
 
-<!-- IMPORTANT
+    The role="application" attribute on the surrounding Div is critical and
+    must be present as a wrapper for all role="menubar" constructs. The
+    aria-label attribute is presented to non-sighted screen reader users who
+    can then quickly navigate to this landmark.
 
-The role="application" attribute on the surrounding Div is critical and must be present as a wrapper for all role="menubar" constructs. The aria-label attribute is presented to non-sighted screen reader users who can then quickly navigate to this landmark.
+    There must be no embedded active elements within the role="application"
+    container that don't consist of A tags that include role="menuitem".
 
-There must be no embedded active elements within the role="application" container that don't consist of A tags that include role="menuitem".
+    (View the setup.js file for implementation specifics.)
+    -->
 
-(View the setup.js file for implementation specifics.)
--->
+          <div class="menubarWrapper" role="application" aria-label="MenuBar">
 
-																				<div class="menubarWrapper" role="application" aria-label="MenuBar">
+    <!-- IMPORTANT
 
-<!-- IMPORTANT
+    The UL tag for the top level Menubar must include role="menubar", and
+    include a unique ID.
 
-The UL tag for the top level Menubar must include role="menubar", and include a unique ID.
+    The 'horizontal' or 'vertical' classes may be used to configure the
+    correct keyboard functionality so that it matches the visual layout of
+    the Menubar.
+    -->
 
-The 'horizontal' or 'vertical' classes may be used to configure the correct keyboard functionality so that it matches the visual layout of the Menubar.
--->
+            <ul id="unique-menubar-id" class="horizontal menubar clearfix" role="menubar">
 
-																								<ul id="unique-menubar-id" class="horizontal menubar clearfix" role="menubar">
+    <!-- IMPORTANT
 
-<!-- IMPORTANT
+    All LI tags within the Menubar and Menu constructs must include
+    role="presentation" to allow for automatic X of Y positioning
+    information to be calculated.
+    -->
 
-All LI tags within the Menubar and Menu constructs must include role="presentation" to allow for automatic X of Y positioning information to be calculated.
--->
+              <li role="presentation">
 
-																												<li role="presentation">
+    <!-- IMPORTANT
 
-<!-- IMPORTANT
+    All A tags must include role="menuitem", and exist as firstChild node
+    elements of LI.
 
-All A tags must include role="menuitem", and exist as firstChild node elements of LI.
+    When an A tag that includes role="menuitem" opens a submenu, it must
+    include a data-submenu-id attribute that points to the ID of the
+    referenced Menu structure (consisting of a UL tag that includes
+    role="menu").
 
-When an A tag that includes role="menuitem" opens a submenu, it must include a data-submenu-id attribute that points to the ID of the referenced Menu structure (consisting of a UL tag that includes role="menu").
+    When a top level role="menuitem" A tag includes the class
+    'navigates-away', dual 'click' and 'mouseover' functionality will
+    automatically be applied to allow for the link to navigate to another
+    page when clicked, or to open a submenu when moused over.
 
-When a top level role="menuitem" A tag includes the class 'navigates-away', dual 'click' and 'mouseover' functionality will automatically be applied to allow for the link to navigate to another page when clicked, or to open a submenu when moused over.
+    Additional inline HTML elements such as Spans may be added to any A tag
+    that includes role="menuitem" in order to customize visual styling.
+    -->
 
-Additional inline HTML elements such as Spans may be added to any A tag that includes role="menuitem" in order to customize visual styling.
--->
+                <a data-submenu-id="google-submenu-id" href="http://google.com/"
+                  class="menubar-link navigates-away opens-submenu" role="menuitem">
+                  <span> Google </span> <span class="menuIcon"></span>
+                </a>
 
-																												<a data-submenu-id="google-submenu-id" href="http://google.com/"
-																													class="menubar-link navigates-away opens-submenu" role="menuitem">
-																												<span> Google </span> <span class="menuIcon"></span> </a>
+    <!-- IMPORTANT
 
-<!-- IMPORTANT
+    The UL tag for all nested Menu structures must include role="menu", and
+    include a unique ID that is referenced by the controlling A tag via its
+    data-submenu-id attribute.
 
-The UL tag for all nested Menu structures must include role="menu", and include a unique ID that is referenced by the controlling A tag via its data-submenu-id attribute.
+    The 'horizontal' or 'vertical' classes may be used to configure the correct
+    keyboard functionality so that it matches the visual layout of the Menu.
 
-The 'horizontal' or 'vertical' classes may be used to configure the correct keyboard functionality so that it matches the visual layout of the Menu.
+    The 'hidden' class must include display:none as part of it's property set
+    within the CSS stylesheet. If changed, this must also be changed within the
+    setup.js file to reference the correct class name for toggling.
 
-The 'hidden' class must include display:none as part of it's property set within the CSS stylesheet. If changed, this must also be changed within the setup.js file to reference the correct class name for toggling.
+    (Change the hiddenClass variable to update this within setup.js if needed)
+    -->
 
-(Change the hiddenClass variable to update this within setup.js if needed)
--->
+                <ul id="google-submenu-id" class="vertical menu hidden" role="menu">
+                  <li role="presentation">
 
-																												<ul id="google-submenu-id" class="vertical menu hidden" role="menu">
-																																<li role="presentation">
+    <!-- IMPORTANT
 
-<!-- IMPORTANT
+    If an A tag that includes role="menuitem" opens a nested submenu from
+    within a UL that includes role="menu", the A tag must also include the
+    attribute href="#". (Do not include a JavaScript void() statement within
+    the href attribute.)
+    -->
 
-If an A tag that includes role="menuitem" opens a nested submenu from within a UL that includes role="menu", the A tag must also include the attribute href="#". (Do not include a JavaScript void() statement within the href attribute.)
--->
+                    <a data-submenu-id="google-news-submenu-id" href="#"
+                      class="menu-link opens-submenu" role="menuitem">
+                      <span>Google News</span> <span class="menuIcon right"></span>
+                    </a>
 
-																																<a data-submenu-id="google-news-submenu-id" href="#"
-																																	class="menu-link opens-submenu" role="menuitem">
-																																<span>Google News</span> <span class="menuIcon right"></span> </a>
+                    <ul id="google-news-submenu-id" class="vertical nested-submenu hidden"
+                      role="menu">
+                      <li role="presentation">
+                        <a href="http://news.google.com/?edchanged=1&ned=us" class="menu-link"
+                          role="menuitem"> <span>US News</span>
+                        </a>
+                      </li>
 
-																																<ul id="google-news-submenu-id" class="vertical nested-submenu hidden"
-																																	role="menu">
-																																				<li role="presentation">
-																																				<a href="http://news.google.com/?edchanged=1&ned=us" class="menu-link"
-																																					role="menuitem"> <span>US News</span> </a> </li>
+                      <li role="presentation">
+                        <a href="http://news.google.com/?edchanged=1&ned=au" class="menu-link"
+                          role="menuitem"> <span>Au News</span>
+                        </a>
+                      </li>
 
-																																				<li role="presentation">
-																																				<a href="http://news.google.com/?edchanged=1&ned=au" class="menu-link"
-																																					role="menuitem"> <span>Au News</span> </a> </li>
+                      <li role="presentation">
+                        <a href="http://news.google.com/?edchanged=1&ned=uk" class="menu-link"
+                          role="menuitem"> <span>UK News</span>
+                        </a>
+                      </li>
+                    </ul>
 
-																																				<li role="presentation">
-																																				<a href="http://news.google.com/?edchanged=1&ned=uk" class="menu-link"
-																																					role="menuitem"> <span>UK News</span> </a> </li>
-																																</ul>
+                  </li>
 
-																																</li>
+                  <li role="presentation">
+                    <a href="http://gmail.google.com/" class="menu-link" role="menuitem">
+                      <span>Google Mail</span>
+                    </a>
+                  </li>
 
-																																<li role="presentation">
-																																<a href="http://gmail.google.com/" class="menu-link" role="menuitem">
-																																<span>Google Mail</span> </a> </li>
+                  <li role="presentation">
+                    <a href="http://groups.google.com/" class="menu-link" role="menuitem">
+                      <span>Google Groups</span>
+                    </a>
+                  </li>
+                </ul>
 
-																																<li role="presentation">
-																																<a href="http://groups.google.com/" class="menu-link" role="menuitem">
-																																<span>Google Groups</span> </a> </li>
-																												</ul>
+              </li>
 
-																												</li>
+              <li role="presentation">
+                <a data-submenu-id="discovery-submenu-id" href="http://news.discovery.com/"
+                  class="menubar-link navigates-away opens-submenu" role="menuitem">
+                  <span>Discovery</span> <span class="menuIcon"></span>
+                </a>
 
-																												<li role="presentation">
-																												<a data-submenu-id="discovery-submenu-id" href="http://news.discovery.com/"
-																													class="menubar-link navigates-away opens-submenu" role="menuitem">
-																												<span>Discovery</span> <span class="menuIcon"></span> </a>
+                <ul id="discovery-submenu-id" class="vertical menu hidden" role="menu">
+                  <li role="presentation">
+                    <a href="http://news.discovery.com/tech" class="menu-link" role="menuitem">
+                      <span>Tech News</span>
+                    </a>
+                  </li>
 
-																												<ul id="discovery-submenu-id" class="vertical menu hidden" role="menu">
-																																<li role="presentation">
-																																<a href="http://news.discovery.com/tech" class="menu-link" role="menuitem">
-																																<span>Tech News</span> </a> </li>
+                  <li role="presentation">
+                    <a href="http://news.discovery.com/space" class="menu-link" role="menuitem">
+                      <span>Space News</span>
+                    </a>
+                  </li>
+                </ul>
 
-																																<li role="presentation">
-																																<a href="http://news.discovery.com/space" class="menu-link" role="menuitem">
-																																<span>Space News</span> </a> </li>
-																												</ul>
+              </li>
 
-																												</li>
+              <li role="presentation">
+                <a data-submenu-id="cbs-submenu-id" href="http://news.cbs.com/"
+                  class="menubar-link navigates-away opens-submenu" role="menuitem">
+                  <span>CBS</span> <span class="menuIcon"></span>
+                </a>
 
-																												<li role="presentation">
-																												<a data-submenu-id="cbs-submenu-id" href="http://news.cbs.com/"
-																													class="menubar-link navigates-away opens-submenu" role="menuitem">
-																												<span>CBS</span> <span class="menuIcon"></span> </a>
+                <ul id="cbs-submenu-id" class="vertical menu hidden" role="menu">
+                  <li role="presentation">
+                    <a href="http://www.cbsnews.com/us/" class="menu-link" role="menuitem">
+                      <span>US News</span>
+                    </a>
+                  </li>
 
-																												<ul id="cbs-submenu-id" class="vertical menu hidden" role="menu">
-																																<li role="presentation">
-																																<a href="http://www.cbsnews.com/us/" class="menu-link" role="menuitem">
-																																<span>US News</span> </a> </li>
+                  <li role="presentation">
+                    <a href="http://www.cbsnews.com/world/" class="menu-link" role="menuitem">
+                      <span>World News</span>
+                    </a>
+                  </li>
 
-																																<li role="presentation">
-																																<a href="http://www.cbsnews.com/world/" class="menu-link" role="menuitem">
-																																<span>World News</span> </a> </li>
+                  <li role="presentation">
+                    <a href="http://www.cbsnews.com/politics/" class="menu-link" role="menuitem">
+                      <span>Political News</span>
+                    </a>
+                  </li>
+                </ul>
 
-																																<li role="presentation">
-																																<a href="http://www.cbsnews.com/politics/" class="menu-link" role="menuitem">
-																																<span>Political News</span> </a> </li>
-																												</ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
 
-																												</li>
-																								</ul>
-																				</div>
-																</div>
-												</div>
-
-												<div role="main">
-																<p>
-																Page body content.
-</p>
-												</div>
-								</div>
-				</body>
+      <div role="main">
+        <p>
+          Page body content.
+        </p>
+      </div>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
This fixes the use of tabs which push much of the content offscreen when using the GitHub interface, making it hard to view the source code. Tabs are replaced with two spaces, which keeps the layout compact but the structure understandable.
